### PR TITLE
Update multi_json

### DIFF
--- a/sinatra-jsonp.gemspec
+++ b/sinatra-jsonp.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.description      = "JSONP output helper for Sinatra"
 
   s.add_dependency "sinatra", "~> 1.0"
-  s.add_dependency "multi_json", "~> 1.3.7"
+  s.add_dependency "multi_json", "~> 1.8"
 
   s.add_development_dependency "rspec", "~> 2.3"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Update the dependency to `multi_json`

Without the update, `sinatra-jsonp` can't be used when a newer version of `multi_json` is otherwise required:

```
Unable to activate sinatra-jsonp-0.4.2, because multi_json-1.8.2 conflicts with multi_json (~> 1.3.7)
```
