### PR TITLE
Add license to gemspec

### DIFF
--- a/sinatra-jsonp.gemspec
+++ b/sinatra-jsonp.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.email            = "serg.podtynnyi@gmail.com"
   s.files            = Dir["**/*.{rb,md}"]+['Rakefile', 'LICENSE']
   s.homepage         = "http://github.com/shtirlic/#{s.name}"
+  s.license          = "MIT"
   s.require_paths    = ["lib"]
   s.summary          = s.description
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.