### PR TITLE
Support Sinatra 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.4
+  - 2.3
+  - 2.2
   - jruby
   - ruby-head
 before_install:

--- a/sinatra-jsonp.gemspec
+++ b/sinatra-jsonp.gemspec
@@ -4,13 +4,14 @@ Gem::Specification.new do |s|
   s.version          = "0.4.4"
   s.description      = "JSONP output helper for Sinatra"
 
-  s.add_dependency "sinatra", "~> 1.0"
+  s.add_dependency "sinatra", ">= 1.0"
   s.add_dependency "multi_json", "~> 1.8"
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rake', '>= 0'
-  s.add_development_dependency 'sinatra-contrib', '~> 1.0'
+  s.add_development_dependency 'sinatra-contrib', '>= 1.0'
   s.add_development_dependency 'test-unit', '~> 3.0.9'
+  s.add_development_dependency 'rack-test', '~> 0.7.0'
 
   s.authors          = ["Serg Podtynnyi"]
   s.email            = "serg.podtynnyi@gmail.com"

--- a/sinatra-jsonp.gemspec
+++ b/sinatra-jsonp.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sinatra", "~> 1.0"
   s.add_dependency "multi_json", "~> 1.8"
 
-  s.add_development_dependency 'rspec', '~> 2.3'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'sinatra-contrib', '~> 1.0'
   s.add_development_dependency 'test-unit', '~> 3.0.9'

--- a/spec/jsonp_spec.rb
+++ b/spec/jsonp_spec.rb
@@ -19,25 +19,25 @@ describe Sinatra::Jsonp do
 
   it "returns JSON if no callback passed" do
     get '/method'
-    body.should == '["hello","hi","hallo"]'
+    expect(body).to eq '["hello","hi","hallo"]'
   end
   it "returns JSONP if callback passed via request params" do
     get '/method?callback=functionA'
-    body.should == 'functionA(["hello","hi","hallo"])'
+    expect(body).to eq 'functionA(["hello","hi","hallo"])'
   end
 
   it "returns JSONP with sanitized callback" do
     get '/method', { :callback=>'foo<script>alert(1)</script>' }
-    body.should == 'fooscriptalert1script(["hello","hi","hallo"])'
+    expect(body).to eq 'fooscriptalert1script(["hello","hi","hallo"])'
   end
 
   it "returns JSONP if callback passed via method param" do
     get '/method_with_params'
-    body.should == 'functionA(["hello","hi","hallo"])'
+    expect(body).to eq 'functionA(["hello","hi","hallo"])'
   end
   it "returns JSONP with callback passed via method params even if it passed via request param" do
     get '/method_with_params?callback=functionB'
-    body.should == 'functionA(["hello","hi","hallo"])'
+    expect(body).to eq 'functionA(["hello","hi","hallo"])'
   end
 
   it "return pretty JSON if :json_pretty enabled" do
@@ -50,6 +50,6 @@ describe Sinatra::Jsonp do
       end
     end
     get '/method'
-    body.should == "[\n  \"hello\",\n  \"hi\",\n  \"hallo\"\n]"
+    expect(body).to eq "[\n  \"hello\",\n  \"hi\",\n  \"hallo\"\n]"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'sinatra/contrib'
 require 'sinatra/jsonp'
 
 RSpec.configure do |config|
-  config.expect_with :rspec, :stdlib
+  config.expect_with :rspec
   config.include Sinatra::TestHelpers
 end
 


### PR DESCRIPTION
Sinatra 2.0 has been released on 7 May 2017.

This PR updates dependent gems for support Sinatra 2.0.
In addition, it refactors test codes.